### PR TITLE
fix: options.slow (ms v2.0.0)

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function reducer (options) {
   var debug = Debug(options.debug || 'koa:timer')
   var threshold = options.threshold || false
   var verbose = options.verbose || false
-  var duration = speed(ms(options.slow) || 75)
+  var duration = speed(options.slow ? ms(options.slow) : 75)
 
   return function _reducer (name, top_start, top_end, bottom_start, bottom_end) {
     var top = top_end - top_start


### PR DESCRIPTION
Base ms v2.0.0, if `options.slow` is undefined, TIMER will throw error.

// ms
```
module.exports = function(val, options) {
  options = options || {};
  var type = typeof val;
  if (type === 'string' && val.length > 0) {
    return parse(val);
  } else if (type === 'number' && isNaN(val) === false) {
    return options.long ? fmtLong(val) : fmtShort(val);
  }
  throw new Error(
    'val is not a non-empty string or a valid number. val=' +
      JSON.stringify(val)
  );
};
```